### PR TITLE
Dependents now show accurately for all atoms

### DIFF
--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/hooks/createAtomNodes.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/hooks/createAtomNodes.ts
@@ -1,169 +1,351 @@
+// import { graphlib, layout } from 'dagre';
+// import { Edge, MarkerType, Node, Position } from 'reactflow';
+// import { AnyAtom, ValuesAtomTuple } from 'src/types';
+// import { useAtomsSnapshots } from '../../../../../../hooks/useAtomsSnapshots';
+// import { atomToPrintable } from '../../../../../../utils';
+// import { SelectedAtomAtomData } from '../../atoms';
+// import classes from '../components/AtomGraphVisual/CustomNode.module.css';
+
+// interface CustomNodeData {
+//   label: string;
+// }
+
+// interface CustomNode extends Node<CustomNodeData, string> {
+//   id: string;
+//   type: string;
+//   position: { x: number; y: number };
+//   data: CustomNodeData;
+//   width?: number;
+//   height?: number;
+//   targetPosition?: Position;
+//   sourcePosition?: Position;
+// }
+
+// // is this necessary? does react already have this type set up?
+// interface CustomEdge extends Edge<any> {
+//   id: string;
+//   source: string;
+//   target: string;
+//   animated?: boolean;
+//   markerEnd?: {
+//     type: string;
+//     width?: number;
+//     height?: number;
+//     color?: string;
+//     className?: any;
+//   };
+//   style?: object;
+// }
+
+// export const useCreateAtomNodes = (
+//   selectedAtomData: SelectedAtomAtomData | undefined,
+//   values: ValuesAtomTuple[],
+// ): { atomNodes: CustomNode[]; atomEdges: CustomEdge[] } => {
+//   const { dependents } = useAtomsSnapshots();
+//   const nodesArray: CustomNode[] = [];
+//   const edgesArray: CustomEdge[] = [];
+
+//   const dagreGraph = new graphlib.Graph();
+//   dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+//   // Set the node spacing
+//   dagreGraph.setGraph({
+//     rankdir: 'LR',
+//     // nodesep: 100, // horiz spacing between nodes
+//     // ranksep: 100, // vert spacing between nodes
+//     // edgesep: 100,
+//   });
+
+//helper function to create individual nodes
+//   const createNode = (atom: AnyAtom, i: number, isParent: boolean) => {
+//     const atomKey = atom.toString();
+//     const nodeId = `atom-list-item-${atomKey + i}`;
+//     dagreGraph.setNode(nodeId, { width: 100, height: 50 });
+
+//     if (isParent) {
+//       dagreGraph.setNode(nodeId, { ParentNode: true, rank: i });
+//     } else {
+//       // Set the rank for child nodes based on their parent's rank
+//       dagreGraph.setNode(nodeId, { ParentNode: false });
+//     }
+
+//     nodesArray.push({
+//       id: nodeId,
+//       type: 'custom',
+//       position: { x: 0, y: 0 },
+//       data: { label: atomToPrintable(atom) },
+//       width: 100,
+//       height: 50,
+//     });
+//     return nodeId;
+//   };
+
+//   if (!selectedAtomData) {
+//     values.forEach(([atom], i) => {
+//       const nodeId = createNode(atom, i, true);
+//       const depsForAtom = Array.from(dependents.get(atom) || []);
+//       depsForAtom.forEach((depAtom) => {
+//         const depNodeId = createNode(depAtom, i, false);
+//         edgesArray.push({
+//           id: `${nodeId}-${depNodeId}`,
+//           source: nodeId,
+//           target: depNodeId,
+//           animated: true,
+//           markerEnd: {
+//             type: MarkerType.ArrowClosed,
+//             width: 20,
+//             height: 20,
+//           },
+//           style: {
+//             strokeWidth: 2,
+//           },
+//         });
+//       });
+//     });
+//   } else {
+//     const atom = selectedAtomData.atom;
+//     const nodeId = createNode(atom, 0, true);
+//     const depsForAtom = Array.from(dependents.get(atom) || []);
+//     depsForAtom.forEach((depAtom) => {
+//       const depNodeId = createNode(depAtom, 0, false);
+//       edgesArray.push({
+//         id: `${nodeId}-${depNodeId}`,
+//         source: nodeId,
+//         target: depNodeId,
+//         animated: true,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         style: {
+//           strokeWidth: 2,
+//         },
+//       });
+//     });
+//   }
+
+//   layout(dagreGraph);
+
+//   let lastParent: string;
+//   let lastParentY = 0;
+//   const parentNodeSpacing = 150;
+
+//   const layoutedNodes = nodesArray.map((node, i) => {
+//     const nodeWithPosition = dagreGraph.node(node.id);
+//     const isParent = nodeWithPosition.ParentNode === true;
+
+//     let position;
+
+//     if (isParent) {
+//       position = {
+//         x: nodeWithPosition.x - node.width! / 2,
+//         y: lastParentY,
+//       };
+//       lastParentY += parentNodeSpacing;
+
+//       lastParent = node.id;
+//     } else {
+//       // this sets the position of the child node next to the parent node
+//       const parentNodePosition = dagreGraph.node(lastParent);
+//       position = {
+//         x: parentNodePosition.x + node.width! * 2.5,
+//         y: lastParentY - node.height! / 2 - 125,
+//       };
+//     }
+
+//     return {
+//       ...node,
+//       targetPosition: Position.Top,
+//       sourcePosition: Position.Bottom,
+//       position,
+//     };
+//   });
+
+//   return { atomNodes: layoutedNodes, atomEdges: edgesArray };
+// };
+
+//___________________________Original above _____________________________________
+
 import { graphlib, layout } from 'dagre';
 import { Edge, MarkerType, Node, Position } from 'reactflow';
 import { AnyAtom, ValuesAtomTuple } from 'src/types';
 import { useAtomsSnapshots } from '../../../../../../hooks/useAtomsSnapshots';
 import { atomToPrintable } from '../../../../../../utils';
 import { SelectedAtomAtomData } from '../../atoms';
-import classes from '../components/AtomGraphVisual/CustomNode.module.css';
+// import classes from '../components/AtomGraphVisual/CustomNode.module.css';
 
-interface CustomNodeData {
-  label: string;
+// ... (rest of the code remains the same)
+
+interface AtomNode {
+  id: string;
+  atom: AnyAtom;
+  parent: AtomNode | null;
+  children: AtomNode[];
 }
 
-interface CustomNode extends Node<CustomNodeData, string> {
-  id: string;
-  type: string;
-  position: { x: number; y: number };
-  data: CustomNodeData;
-  width?: number;
-  height?: number;
-  targetPosition?: Position;
-  sourcePosition?: Position;
-}
-
-// is this necessary? does react already have this type set up?
-interface CustomEdge extends Edge<any> {
-  id: string;
-  source: string;
-  target: string;
-  animated?: boolean;
-  markerEnd?: {
-    type: string;
-    width?: number;
-    height?: number;
-    color?: string;
-    className?: any;
+const createAtomNode = (
+  atom: AnyAtom,
+  parent: AtomNode | null = null,
+): AtomNode => {
+  return {
+    id: `atom-${atom.toString()}`,
+    atom,
+    parent,
+    children: [],
   };
-  style?: object;
-}
+};
+
+const buildAtomTree = (
+  atoms: AnyAtom[],
+  dependents: Map<AnyAtom, Set<AnyAtom>>,
+  atomMap: Map<AnyAtom, AtomNode>,
+): AtomNode[] => {
+  const relationships: [AnyAtom, AnyAtom][] = [];
+
+  atoms.forEach((atom) => {
+    if (!atomMap.has(atom)) {
+      atomMap.set(atom, createAtomNode(atom));
+    }
+  });
+
+  atoms.forEach((atom) => {
+    const node = atomMap.get(atom)!;
+    const depsForAtom = Array.from(dependents.get(atom) || []);
+
+    depsForAtom.forEach((depAtom) => {
+      let depNode = atomMap.get(depAtom);
+      if (!depNode) {
+        depNode = createAtomNode(depAtom);
+        atomMap.set(depAtom, depNode);
+      }
+      relationships.push([atom, depAtom]);
+    });
+  });
+
+  relationships.forEach(([parentAtom, childAtom]) => {
+    const parentNode = atomMap.get(parentAtom)!;
+    const childNode = atomMap.get(childAtom)!;
+    if (!childNode.parent) {
+      childNode.parent = parentNode;
+    }
+    parentNode.children.push(childNode);
+  });
+
+  return Array.from(atomMap.values()).filter((node) => !node.parent);
+};
+
+const layoutNodes = (nodes: AtomNode[], dagreGraph: graphlib.Graph): void => {
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: 100, height: 50 });
+    node.children.forEach((child) => {
+      dagreGraph.setEdge(node.id, child.id);
+    });
+    layoutNodes(node.children, dagreGraph);
+  });
+};
+
+const createNodeComponent = (node: AtomNode): Node => {
+  return {
+    id: node.id,
+    type: 'custom',
+    position: { x: 0, y: 0 },
+    data: { label: atomToPrintable(node.atom) },
+    width: 100,
+    height: 50,
+  };
+};
+
+const createEdgeComponent = (source: AtomNode, target: AtomNode): Edge => {
+  return {
+    id: `${source.id}-${target.id}`,
+    source: source.id,
+    target: target.id,
+    animated: true,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 20,
+      height: 20,
+    },
+    style: {
+      strokeWidth: 2,
+    },
+  };
+};
+
+const buildComponents = (
+  nodes: AtomNode[],
+  atomMap: Map<AnyAtom, AtomNode>,
+): { atomNodes: Node[]; atomEdges: Edge[] } => {
+  const atomNodes: Node[] = [];
+  const atomEdges: Edge[] = [];
+
+  const traverseNodes = (node: AtomNode) => {
+    atomNodes.push(createNodeComponent(node));
+    node.children.forEach((child) => {
+      if (atomMap.has(node.atom) && atomMap.has(child.atom)) {
+        atomEdges.push(createEdgeComponent(node, child));
+      }
+      traverseNodes(child);
+    });
+  };
+
+  nodes.forEach(traverseNodes);
+  return { atomNodes, atomEdges };
+};
 
 export const useCreateAtomNodes = (
   selectedAtomData: SelectedAtomAtomData | undefined,
   values: ValuesAtomTuple[],
-): { atomNodes: CustomNode[]; atomEdges: CustomEdge[] } => {
+): { atomNodes: Node[]; atomEdges: Edge[] } => {
   const { dependents } = useAtomsSnapshots();
-  const nodesArray: CustomNode[] = [];
-  const edgesArray: CustomEdge[] = [];
 
   const dagreGraph = new graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => ({}));
-
-  // Set the node spacing
   dagreGraph.setGraph({
     rankdir: 'LR',
-    // nodesep: 100, // horiz spacing between nodes
-    // ranksep: 100, // vert spacing between nodes
-    // edgesep: 100,
+    nodesep: 100,
+    ranksep: 150,
+    edgesep: 150,
   });
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
 
-  //helper function to create individual nodes
-  const createNode = (atom: AnyAtom, i: number, isParent: boolean) => {
-    const atomKey = atom.toString();
-    const nodeId = `atom-list-item-${atomKey + i}`;
-    dagreGraph.setNode(nodeId, { width: 100, height: 50 });
-
-    if (isParent) {
-      dagreGraph.setNode(nodeId, { ParentNode: true, rank: i });
-    } else {
-      // Set the rank for child nodes based on their parent's rank
-      dagreGraph.setNode(nodeId, { ParentNode: false });
-    }
-
-    nodesArray.push({
-      id: nodeId,
-      type: 'custom',
-      position: { x: 0, y: 0 },
-      data: { label: atomToPrintable(atom) },
-      width: 100,
-      height: 50,
-    });
-    return nodeId;
-  };
-
-  if (!selectedAtomData) {
-    values.forEach(([atom], i) => {
-      const nodeId = createNode(atom, i, true);
+  let atoms: AnyAtom[];
+  if (selectedAtomData) {
+    atoms = [selectedAtomData.atom];
+    const getDependentAtoms = (atom: AnyAtom): AnyAtom[] => {
       const depsForAtom = Array.from(dependents.get(atom) || []);
-      depsForAtom.forEach((depAtom) => {
-        const depNodeId = createNode(depAtom, i, false);
-        edgesArray.push({
-          id: `${nodeId}-${depNodeId}`,
-          source: nodeId,
-          target: depNodeId,
-          animated: true,
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            width: 20,
-            height: 20,
-          },
-          style: {
-            strokeWidth: 2,
-          },
-        });
-      });
-    });
+      return [...depsForAtom, ...depsForAtom.flatMap(getDependentAtoms)];
+    };
+    atoms = [...atoms, ...getDependentAtoms(selectedAtomData.atom)];
   } else {
-    const atom = selectedAtomData.atom;
-    const nodeId = createNode(atom, 0, true);
-    const depsForAtom = Array.from(dependents.get(atom) || []);
-    depsForAtom.forEach((depAtom) => {
-      const depNodeId = createNode(depAtom, 0, false);
-      edgesArray.push({
-        id: `${nodeId}-${depNodeId}`,
-        source: nodeId,
-        target: depNodeId,
-        animated: true,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        style: {
-          strokeWidth: 2,
-        },
-      });
-    });
+    atoms = values.map(([atom]) => atom);
   }
+
+  const atomMap = new Map(atoms.map((atom) => [atom, createAtomNode(atom)]));
+  const rootNodes = buildAtomTree(atoms, dependents, atomMap);
+  layoutNodes(rootNodes, dagreGraph);
+  const { atomNodes, atomEdges } = buildComponents(rootNodes, atomMap);
+
+  // Filter out edges with null or undefined targets
+  // atomEdges = atomEdges.filter(
+  //   (edge) => edge.target !== null && edge.target !== undefined,
+  // );
 
   layout(dagreGraph);
 
-  let lastParent: string;
-  let lastParentY = 0;
-  const parentNodeSpacing = 150;
-
-  const layoutedNodes = nodesArray.map((node, i) => {
+  atomNodes.forEach((node) => {
     const nodeWithPosition = dagreGraph.node(node.id);
-    const isParent = nodeWithPosition.ParentNode === true;
-
-    let position;
-
-    if (isParent) {
-      position = {
-        x: nodeWithPosition.x - node.width! / 2,
-        y: lastParentY,
-      };
-      lastParentY += parentNodeSpacing;
-
-      lastParent = node.id;
-    } else {
-      // this sets the position of the child node next to the parent node
-      const parentNodePosition = dagreGraph.node(lastParent);
-      position = {
-        x: parentNodePosition.x + node.width! * 2.5,
-        y: lastParentY - node.height! / 2 - 125,
-      };
-    }
-
-    return {
-      ...node,
-      targetPosition: Position.Top,
-      sourcePosition: Position.Bottom,
-      position,
+    node.targetPosition = Position.Left;
+    node.sourcePosition = Position.Right;
+    node.position = {
+      x: nodeWithPosition.x - node.width! / 2,
+      y: nodeWithPosition.y,
     };
   });
 
-  return { atomNodes: layoutedNodes, atomEdges: edgesArray };
+  return { atomNodes, atomEdges };
 };
+//_________________________TEST ABove_____________________________________________
 
 //____
 // import * as React from 'react';

--- a/src/stories/Default/Demos/Random.tsx
+++ b/src/stories/Default/Demos/Random.tsx
@@ -4,6 +4,35 @@ import { useAtom, useAtomValue } from 'jotai/react';
 import { atom } from 'jotai/vanilla';
 import { demoStoreOptions } from './demo-store';
 
+const aVeryBigSetOfAtoms = Array.from({ length: 10 }, (_, i) => {
+  const anAtom = atom(i);
+  anAtom.debugLabel = `anAtom${i}`;
+  return anAtom;
+});
+
+const anBigAtomHolder = atom((get) => {
+  return aVeryBigSetOfAtoms.map((a) => get(a));
+});
+
+anBigAtomHolder.debugLabel = 'anBigAtomHolder';
+
+const createDependentAtomChain = (depth, initialValue = 0) => {
+  if (depth === 0) {
+    const baseAtom = atom(initialValue);
+    baseAtom.debugLabel = `baseAtom-${initialValue}`;
+    return baseAtom;
+  }
+
+  const parentAtom = createDependentAtomChain(depth - 1, initialValue);
+  const childAtom = atom((get) => get(parentAtom) + 1);
+  childAtom.debugLabel = `childAtom-${depth}-${initialValue}`;
+  return childAtom;
+};
+
+const shallowChain = createDependentAtomChain(10);
+// const mediumChain = createDependentAtomChain(50);
+// const deepChain = createDependentAtomChain(100);
+
 const countAtom = atom(1);
 countAtom.debugLabel = 'randomCountAtom';
 
@@ -34,6 +63,15 @@ const nestedObjectAtom = atom((get) => {
 });
 
 nestedObjectAtom.debugLabel = 'nestedObjectAtom';
+
+const dependentOfNestedObjectAtom = atom((get) => {
+  const { nestedObject } = get(nestedObjectAtom);
+  return {
+    quadrupleCount: nestedObject.doubleCount * 2,
+    sixTimesCount: nestedObject.tripleCount * 2,
+  };
+});
+dependentOfNestedObjectAtom.debugLabel = 'dependentOfNestedObjectAtom';
 
 const atomsInAtomsCountAtom = atom(atom(atom((get) => get(countAtom))));
 atomsInAtomsCountAtom.debugLabel = 'atomsInAtomsCountAtom';
@@ -68,6 +106,11 @@ export const Random = () => {
   useAtomValue(atomReturnsUndefined, demoStoreOptions);
   useAtomValue(atomWithSomeSymbol, demoStoreOptions);
   useAtomValue(atomWithFunction, demoStoreOptions);
+  useAtomValue(dependentOfNestedObjectAtom, demoStoreOptions);
+  useAtomValue(anBigAtomHolder, demoStoreOptions);
+  useAtomValue(shallowChain, demoStoreOptions);
+  // useAtomValue(mediumChain, demoStoreOptions);
+  // useAtomValue(deepChain, demoStoreOptions);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const atomsInAtomsCount = useAtomValue(


### PR DESCRIPTION
Dependents now show accurately for all atoms. Updated the atom graph to display the entire chain of dependents for each atom and not repeat dependent atoms. 