### PR TITLE
ReactFlow Controls Styling Updated to Mantine

### DIFF
--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.css
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.css
@@ -1,60 +1,41 @@
-/* @import "~@mantine/core/styles/Button.css"; */
-
 .internal-jotai-devtools-graph-container {
     width: 100%;
     height: 100%;
   }
 
+
+//react-flow_controls component styling override to match Mantine styling
+.react-flow__controls {
+  box-shadow: 0 0 0px 0px rgba(0, 0, 0, 0);
+}
+
 .react-flow__controls button {
-  /* background-color: var(--bg-color);
-  color: var(--text-color);
-  border: 1px solid #95679e;
-  border-bottom: none; */
-
-  /* --button-height-xs: 30px;
-  --button-height-sm: 36px;
-  --button-height-md: 42px;
-  --button-height-lg: 50px;
-  --button-height-xl: 60px;
-
-  --button-height-compact-xs: 22px;
-  --button-height-compact-sm: 26px;
-  --button-height-compact-md: 30px;
-  --button-height-compact-lg: 34px;
-  --button-height-compact-xl: 40px;
-
-  --button-padding-x-xs: 14px;
-  --button-padding-x-sm: 18px;
-  --button-padding-x-md: 22px;
-  --button-padding-x-lg: 26px;
-  --button-padding-x-xl: 32px;
-
-  --button-padding-x-compact-xs: 7px;
-  --button-padding-x-compact-sm: 8px;
-  --button-padding-x-compact-md: 10px;
-  --button-padding-x-compact-lg: 12px;
-  --button-padding-x-compact-xl: 14px;
-
-  --button-height: var(--button-height-sm);
-  --button-padding-x: var(--button-padding-x-sm);
-  --button-color: var(--mantine-color-white);
-
-  user-select: none;
-  font-weight: 600;
-  position: relative;
-  line-height: 1;
-  text-align: center;
-  overflow: hidden;
-
-  width: auto;
-  cursor: pointer;
-  display: inline-block;
-  border-radius: var(--button-radius, var(--mantine-radius-default));
-  font-size: var(--button-fz, var(--mantine-font-size-sm));
+  color: var(--button-color, var(--mantine-color-white));
   background: var(--button-bg, var(--mantine-primary-color-filled));
   border: var(--button-bd, calc(0.0625rem * var(--mantine-scale)) solid transparent);
-  color: var(--button-color, var(--mantine-color-white));
-  height: var(--button-height, var(--button-height-sm));
-  padding-inline: var(--button-padding-x, var(--button-padding-x-sm));
-  vertical-align: middle; */
+  border-radius: var(--button-radius, var(--mantine-radius-default));
+  box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+
+    [data-mantine-color-scheme='dark'] & {
+      background: var(--mantine-color-gray-1);
+  }
+}
+
+.react-flow__controls button:hover {
+  background: var(--mantine-color-dark-8);
+
+    [data-mantine-color-scheme='dark'] & {
+      background: var(--mantine-color-gray-1);
+  }
+} 
+
+.react-flow__controls button svg {
+  fill: var(--mantine-color-white);
+  width: 16px;
+  height: 16px;
+  
+    [data-mantine-color-scheme='dark'] & {
+      fill: var(--mantine-color-dark-6);
+  }
 }

--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.css
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.css
@@ -1,4 +1,60 @@
+/* @import "~@mantine/core/styles/Button.css"; */
+
 .internal-jotai-devtools-graph-container {
     width: 100%;
     height: 100%;
   }
+
+.react-flow__controls button {
+  /* background-color: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid #95679e;
+  border-bottom: none; */
+
+  /* --button-height-xs: 30px;
+  --button-height-sm: 36px;
+  --button-height-md: 42px;
+  --button-height-lg: 50px;
+  --button-height-xl: 60px;
+
+  --button-height-compact-xs: 22px;
+  --button-height-compact-sm: 26px;
+  --button-height-compact-md: 30px;
+  --button-height-compact-lg: 34px;
+  --button-height-compact-xl: 40px;
+
+  --button-padding-x-xs: 14px;
+  --button-padding-x-sm: 18px;
+  --button-padding-x-md: 22px;
+  --button-padding-x-lg: 26px;
+  --button-padding-x-xl: 32px;
+
+  --button-padding-x-compact-xs: 7px;
+  --button-padding-x-compact-sm: 8px;
+  --button-padding-x-compact-md: 10px;
+  --button-padding-x-compact-lg: 12px;
+  --button-padding-x-compact-xl: 14px;
+
+  --button-height: var(--button-height-sm);
+  --button-padding-x: var(--button-padding-x-sm);
+  --button-color: var(--mantine-color-white);
+
+  user-select: none;
+  font-weight: 600;
+  position: relative;
+  line-height: 1;
+  text-align: center;
+  overflow: hidden;
+
+  width: auto;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: var(--button-radius, var(--mantine-radius-default));
+  font-size: var(--button-fz, var(--mantine-font-size-sm));
+  background: var(--button-bg, var(--mantine-primary-color-filled));
+  border: var(--button-bd, calc(0.0625rem * var(--mantine-scale)) solid transparent);
+  color: var(--button-color, var(--mantine-color-white));
+  height: var(--button-height, var(--button-height-sm));
+  padding-inline: var(--button-padding-x, var(--button-padding-x-sm));
+  vertical-align: middle; */
+}

--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.tsx
@@ -4,7 +4,6 @@ import { atomWithDefault } from 'jotai/vanilla/utils';
 import ReactFlow, {
   Background,
   BackgroundVariant,
-  ControlButton,
   Controls,
   getNodesBounds,
   useEdgesState,
@@ -94,13 +93,7 @@ export const AtomGraphVisual = React.memo(() => {
         // onlyRenderVisibleElements={true}
         translateExtent={boundry}
       >
-        {/* <div
-        // style={{ backgroundColor: darkMode ? '#C0C2C9' : '#F5F5F5' }}
-        // style={{ backgroundColor: '#C0C2C9' }}
-        // className="dark:bg-slate-900"
-        // > */}
         <Controls showInteractive={false} />
-        {/* </div> */}
         <Background
           color={useThemeMode('#CED4DA', '#424242')}
           variant={BackgroundVariant.Dots}

--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/components/AtomGraphVisual/AtomGraphVisual.tsx
@@ -4,6 +4,7 @@ import { atomWithDefault } from 'jotai/vanilla/utils';
 import ReactFlow, {
   Background,
   BackgroundVariant,
+  ControlButton,
   Controls,
   getNodesBounds,
   useEdgesState,
@@ -57,7 +58,7 @@ export const AtomGraphVisual = React.memo(() => {
     [+Infinity, +Infinity],
   ]);
 
-  const { fitBounds } = useReactFlow();
+  const { fitView } = useReactFlow();
 
   React.useEffect(() => {
     setNodes(atomNodes);
@@ -73,7 +74,7 @@ export const AtomGraphVisual = React.memo(() => {
         [-150 + bounds.x, -150 + bounds.y],
         [100 + bounds.width + bounds.x, 100 + bounds.height + bounds.y],
       ]);
-      fitBounds(bounds);
+      fitView({ padding: 3, duration: 100 });
     }
   }, [nodes]);
 
@@ -93,13 +94,13 @@ export const AtomGraphVisual = React.memo(() => {
         // onlyRenderVisibleElements={true}
         translateExtent={boundry}
       >
-        <div
-          //   style={{ backgroundColor: darkMode ? '#C0C2C9' : '#F5F5F5' }}
-          style={{ backgroundColor: '#C0C2C9' }}
-          className="dark:bg-slate-900"
-        >
-          <Controls showInteractive={false} />
-        </div>
+        {/* <div
+        // style={{ backgroundColor: darkMode ? '#C0C2C9' : '#F5F5F5' }}
+        // style={{ backgroundColor: '#C0C2C9' }}
+        // className="dark:bg-slate-900"
+        // > */}
+        <Controls showInteractive={false} />
+        {/* </div> */}
         <Background
           color={useThemeMode('#CED4DA', '#424242')}
           variant={BackgroundVariant.Dots}

--- a/src/DevTools/Extension/components/Shell/components/AtomGraph/hooks/createAtomNodes.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomGraph/hooks/createAtomNodes.ts
@@ -78,7 +78,7 @@ const layoutNodes = (nodes: AtomNode[], dagreGraph: graphlib.Graph): void => {
   });
 };
 
-//Creates a node component for rendering in the visualization based on an atom node
+// Creates a node component for rendering in the visualization based on an atom node
 const createNodeComponent = (node: AtomNode): Node => {
   return {
     id: node.id,

--- a/storybook-static/project.json
+++ b/storybook-static/project.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": 1713975967334,
+  "generatedAt": 1714062426273,
   "hasCustomBabel": false,
   "hasCustomWebpack": true,
   "hasStaticDirs": false,

--- a/storybook-static/project.json
+++ b/storybook-static/project.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": 1714062426273,
+  "generatedAt": 1714160233622,
   "hasCustomBabel": false,
   "hasCustomWebpack": true,
   "hasStaticDirs": false,


### PR DESCRIPTION
Added css styling to AtomGraphVisual.css to override the ReactFlow Controls to match the Mantine styling